### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/packages/redae-router/package.json
+++ b/packages/redae-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redae/router",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "redae routing for React",
   "license": "MIT",
   "type": "module",

--- a/packages/vite-plugin-lib-assets/package.json
+++ b/packages/vite-plugin-lib-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redae/vite-plugin-lib-assets",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "A Vite Plugin extracts resource files referenced in library mode instead of embedded them as base64.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
- Updated version from `0.1.0` to `1.0.0` in `@redae/vite-plugin-lib-assets/package.json` to signify a major release for significant changes or enhancements.