### PR TITLE
feat: add @redae/nextjs-combine-middleware package

### DIFF
--- a/packages/nextjs-combine-middleware/lib/combine.ts
+++ b/packages/nextjs-combine-middleware/lib/combine.ts
@@ -1,0 +1,40 @@
+import {PathRegExp} from "@marvinh/path-to-regexp";
+import {NextRequest, NextResponse} from "next/server";
+import {Middleware} from "./types";
+
+export const combineMiddlewares = (
+  middlewares: Middleware[],
+) => {
+  const matchers = middlewares.reduce((matchers: string[], {matcher}) => {
+    matchers.push(...matcher);
+    return matchers;
+  }, []);
+
+  const pathCache = new Map<string, PathRegExp>();
+
+  return {
+    middleware(req: NextRequest) {
+      for (const {matcher, handler} of middlewares) {
+        for (const path of matcher) {
+          let Path = pathCache.get(path);
+          if (!Path) {
+            Path = new PathRegExp(decodeURIComponent(path));
+            pathCache.set(path, Path);
+          }
+          const matchResult = Path.match(req.nextUrl.pathname);
+          if (matchResult) {
+            const response = handler(req);
+            if (response) {
+              return response;
+            }
+          }
+        }
+      }
+
+      return NextResponse.next();
+    },
+    config: {
+      matcher: matchers,
+    },
+  };
+};

--- a/packages/nextjs-combine-middleware/lib/index.ts
+++ b/packages/nextjs-combine-middleware/lib/index.ts
@@ -1,0 +1,2 @@
+export * from "./combine";
+export * from "./middleware";

--- a/packages/nextjs-combine-middleware/lib/middleware.ts
+++ b/packages/nextjs-combine-middleware/lib/middleware.ts
@@ -1,0 +1,3 @@
+import {Middleware} from "./types";
+
+export const defineMiddleware = (mw: Middleware): Middleware => mw;

--- a/packages/nextjs-combine-middleware/lib/types.ts
+++ b/packages/nextjs-combine-middleware/lib/types.ts
@@ -1,0 +1,6 @@
+import {NextRequest, NextResponse} from "next/server";
+
+export interface Middleware {
+  matcher: string[];
+  handler: (req: NextRequest) => NextResponse | null;
+}

--- a/packages/nextjs-combine-middleware/license
+++ b/packages/nextjs-combine-middleware/license
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Dmitriy Chukhno
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/nextjs-combine-middleware/package.json
+++ b/packages/nextjs-combine-middleware/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@redae/nextjs-combine-middleware",
+  "version": "1.0.0",
+  "description": "Middleware management for Next.js based on pathname matching.",
+  "keywords": [
+    "next.js",
+    "middleware",
+    "pathname",
+    "routing"
+  ],
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js"
+    }
+  },
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "build": "tsc && vite build",
+    "publish": "yarn npm publish --tolerate-republish"
+  },
+  "devDependencies": {
+    "@marvinh/path-to-regexp": "^3.1.0",
+    "next": "^14.2.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "5.4.2",
+    "vite": "^5.3.1",
+    "vite-plugin-dts": "^3.9.1"
+  },
+  "peerDependencies": {
+    "next": "^14.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/nextjs-combine-middleware/readme.md
+++ b/packages/nextjs-combine-middleware/readme.md
@@ -1,0 +1,65 @@
+# 💜 @redae/nextjs-combine-middleware
+
+Package for Next.js that simplifies middleware management based on pathname matching. It allows developers to define middleware sets and apply them to requests automatically, depending on the URL paths.
+
+## Install
+
+```bash
+npm i @redae/nextjs-combine-middleware -D
+```
+
+Or
+
+```bash
+yarn add @redae/nextjs-combine-middleware -D
+```
+
+Or
+
+```bash
+pnpm add @redae/nextjs-combine-middleware -D
+```
+
+## Usage
+
+```typescript
+// middleware.ts
+export {middleware, config} from "./middlewares";
+```
+
+```typescript
+//middlewares/index.ts
+import {combineMiddlewares} from "@redae/nextjs-combine-middleware";
+import {auth} from "./auth";
+
+export const {middleware, config} = combineMiddlewares([auth]);
+```
+
+```typescript
+//middlewares/auth.ts
+import {NextRequest, NextResponse} from "next/server";
+import {defineMiddleware} from "@redae/nextjs-combine-middleware";
+
+export const auth = defineMiddleware({
+  matcher: ["/@me", "/signin"],
+  handler: (req: NextRequest) => {
+    const token = req.cookies.get("token")?.value;
+
+    const {pathname} = req.nextUrl;
+
+    if (pathname === "/@me" && !token) {
+      return NextResponse.redirect(new URL("/signin", req.url));
+    }
+
+    if (pathname === "/signin" && token) {
+      return NextResponse.redirect(new URL("/@me", req.url));
+    }
+
+    return NextResponse.next();
+  },
+});
+```
+
+## Contributors
+
+[![contributors](https://contrib.rocks/image?repo=revisedae/redae)](https://github.com/revisedae/redae/graphs/contributors)

--- a/packages/nextjs-combine-middleware/tsconfig.json
+++ b/packages/nextjs-combine-middleware/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.base.json"
+}

--- a/packages/nextjs-combine-middleware/vite.config.ts
+++ b/packages/nextjs-combine-middleware/vite.config.ts
@@ -1,0 +1,25 @@
+import {resolve} from "path";
+import {defineConfig} from "vite";
+import dts from "vite-plugin-dts";
+
+export default defineConfig({
+  plugins: [
+    dts({
+      outDir: ["dist"],
+      rollupTypes: true,
+      clearPureImport: true,
+    }),
+  ],
+  build: {
+    lib: {
+      entry: resolve(__dirname, "lib/index.ts"),
+      fileName: () => "index.js",
+      formats: ["es"],
+    },
+    rollupOptions: {
+      external: [
+        "next/server",
+      ],
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,6 +536,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@marvinh/path-to-regexp@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@marvinh/path-to-regexp@npm:3.1.0"
+  checksum: 10c0/6be2a93626291af828a588ff93f7fae13309435b48c9812f4794f1e6707cfd58e9e247b9b4dd80218c8bf2e89a57eef70bba9eeed8aef04398f5aba9c7d264c5
+  languageName: node
+  linkType: hard
+
 "@microsoft/api-extractor-model@npm:7.28.13":
   version: 7.28.13
   resolution: "@microsoft/api-extractor-model@npm:7.28.13"
@@ -586,6 +593,76 @@ __metadata:
   version: 0.14.2
   resolution: "@microsoft/tsdoc@npm:0.14.2"
   checksum: 10c0/c018857ad439144559ce34a397a29ace7cf5b24b999b8e3c1b88d878338088b3a453eaac4435beaf2c7eae13c4c0aac81e42f96f0f1d48e8d4eeb438eb3bb82f
+  languageName: node
+  linkType: hard
+
+"@next/env@npm:14.2.4":
+  version: 14.2.4
+  resolution: "@next/env@npm:14.2.4"
+  checksum: 10c0/cc284e3dd0666df04d8321645d8409c10cb8e325884c226abbb2e7bea20f0a4232f988216aa506a9d0457b46f28b594a61179d1e978c0ca22497cd8cab8196c7
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-arm64@npm:14.2.4":
+  version: 14.2.4
+  resolution: "@next/swc-darwin-arm64@npm:14.2.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-x64@npm:14.2.4":
+  version: 14.2.4
+  resolution: "@next/swc-darwin-x64@npm:14.2.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-gnu@npm:14.2.4":
+  version: 14.2.4
+  resolution: "@next/swc-linux-arm64-gnu@npm:14.2.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-musl@npm:14.2.4":
+  version: 14.2.4
+  resolution: "@next/swc-linux-arm64-musl@npm:14.2.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-x64-gnu@npm:14.2.4":
+  version: 14.2.4
+  resolution: "@next/swc-linux-x64-gnu@npm:14.2.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-x64-musl@npm:14.2.4":
+  version: 14.2.4
+  resolution: "@next/swc-linux-x64-musl@npm:14.2.4"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-arm64-msvc@npm:14.2.4":
+  version: 14.2.4
+  resolution: "@next/swc-win32-arm64-msvc@npm:14.2.4"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-ia32-msvc@npm:14.2.4":
+  version: 14.2.4
+  resolution: "@next/swc-win32-ia32-msvc@npm:14.2.4"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-x64-msvc@npm:14.2.4":
+  version: 14.2.4
+  resolution: "@next/swc-win32-x64-msvc@npm:14.2.4"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -999,6 +1076,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@redae/nextjs-combine-middleware@workspace:packages/nextjs-combine-middleware":
+  version: 0.0.0-use.local
+  resolution: "@redae/nextjs-combine-middleware@workspace:packages/nextjs-combine-middleware"
+  dependencies:
+    "@marvinh/path-to-regexp": "npm:^3.1.0"
+    next: "npm:^14.2.4"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    typescript: "npm:5.4.2"
+    vite: "npm:^5.3.1"
+    vite-plugin-dts: "npm:^3.9.1"
+  peerDependencies:
+    next: ^14.0.0
+  languageName: unknown
+  linkType: soft
+
 "@redae/router@workspace:packages/redae-router":
   version: 0.0.0-use.local
   resolution: "@redae/router@workspace:packages/redae-router"
@@ -1310,6 +1403,23 @@ __metadata:
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
   checksum: 10c0/ef6351ae073c45c2ac89494dbb3e1f87cc60a93ce4cde797b782812b6f97da0d620ae81973f104b43c9b7eaa789ad20ba4f6a1359f1cc62f63729a55a7d22d4e
+  languageName: node
+  linkType: hard
+
+"@swc/counter@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@swc/counter@npm:0.1.3"
+  checksum: 10c0/8424f60f6bf8694cfd2a9bca45845bce29f26105cda8cf19cdb9fd3e78dc6338699e4db77a89ae449260bafa1cc6bec307e81e7fb96dbf7dcfce0eea55151356
+  languageName: node
+  linkType: hard
+
+"@swc/helpers@npm:0.5.5":
+  version: 0.5.5
+  resolution: "@swc/helpers@npm:0.5.5"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/21a9b9cfe7e00865f9c9f3eb4c1cc5b397143464f7abee76a2c5366e591e06b0155b5aac93fe8269ef8d548df253f6fd931e9ddfc0fd12efd405f90f45506e7d
   languageName: node
   linkType: hard
 
@@ -1944,6 +2054,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"busboy@npm:1.6.0":
+  version: 1.6.0
+  resolution: "busboy@npm:1.6.0"
+  dependencies:
+    streamsearch: "npm:^1.1.0"
+  checksum: 10c0/fa7e836a2b82699b6e074393428b91ae579d4f9e21f5ac468e1b459a244341d722d2d22d10920cdd849743dbece6dca11d72de939fb75a7448825cf2babfba1f
+  languageName: node
+  linkType: hard
+
 "byte-size@npm:8.1.1":
   version: 8.1.1
   resolution: "byte-size@npm:8.1.1"
@@ -2013,6 +2132,13 @@ __metadata:
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
   checksum: 10c0/92ff9b443bfe8abb15f2b1513ca182d16126359ad4f955ebc83dc4ddcc4ef3fdd2c078bc223f2673dc223488e75c99b16cc4d056624374b799e6a1555cf61b23
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001579":
+  version: 1.0.30001640
+  resolution: "caniuse-lite@npm:1.0.30001640"
+  checksum: 10c0/d87fce999e52c354029893a23887d2e48ac297e3af55bd14161fcafdd711f97bdb2649c79d2d3049e628603cb59bc4257ca2961644b0b8d206e7b7dd126d37ea
   languageName: node
   linkType: hard
 
@@ -2109,6 +2235,13 @@ __metadata:
   version: 3.0.0
   resolution: "cli-width@npm:3.0.0"
   checksum: 10c0/125a62810e59a2564268c80fdff56c23159a7690c003e34aeb2e68497dccff26911998ff49c33916fcfdf71e824322cc3953e3f7b48b27267c7a062c81348a9a
+  languageName: node
+  linkType: hard
+
+"client-only@npm:0.0.1":
+  version: 0.0.1
+  resolution: "client-only@npm:0.0.1"
+  checksum: 10c0/9d6cfd0c19e1c96a434605added99dff48482152af791ec4172fb912a71cff9027ff174efd8cdb2160cc7f377543e0537ffc462d4f279bc4701de3f2a3c4b358
   languageName: node
   linkType: hard
 
@@ -3315,7 +3448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:4.2.11, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:4.2.11, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -4838,7 +4971,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.7":
+"nanoid@npm:^3.3.6, nanoid@npm:^3.3.7":
   version: 3.3.7
   resolution: "nanoid@npm:3.3.7"
   bin:
@@ -4858,6 +4991,64 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 10c0/c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
+  languageName: node
+  linkType: hard
+
+"next@npm:^14.2.4":
+  version: 14.2.4
+  resolution: "next@npm:14.2.4"
+  dependencies:
+    "@next/env": "npm:14.2.4"
+    "@next/swc-darwin-arm64": "npm:14.2.4"
+    "@next/swc-darwin-x64": "npm:14.2.4"
+    "@next/swc-linux-arm64-gnu": "npm:14.2.4"
+    "@next/swc-linux-arm64-musl": "npm:14.2.4"
+    "@next/swc-linux-x64-gnu": "npm:14.2.4"
+    "@next/swc-linux-x64-musl": "npm:14.2.4"
+    "@next/swc-win32-arm64-msvc": "npm:14.2.4"
+    "@next/swc-win32-ia32-msvc": "npm:14.2.4"
+    "@next/swc-win32-x64-msvc": "npm:14.2.4"
+    "@swc/helpers": "npm:0.5.5"
+    busboy: "npm:1.6.0"
+    caniuse-lite: "npm:^1.0.30001579"
+    graceful-fs: "npm:^4.2.11"
+    postcss: "npm:8.4.31"
+    styled-jsx: "npm:5.1.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.41.2
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    sass: ^1.3.0
+  dependenciesMeta:
+    "@next/swc-darwin-arm64":
+      optional: true
+    "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-linux-arm64-gnu":
+      optional: true
+    "@next/swc-linux-arm64-musl":
+      optional: true
+    "@next/swc-linux-x64-gnu":
+      optional: true
+    "@next/swc-linux-x64-musl":
+      optional: true
+    "@next/swc-win32-arm64-msvc":
+      optional: true
+    "@next/swc-win32-ia32-msvc":
+      optional: true
+    "@next/swc-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@playwright/test":
+      optional: true
+    sass:
+      optional: true
+  bin:
+    next: dist/bin/next
+  checksum: 10c0/630c2a197b57c1f29caf4672a0f8fb74dbb048e77e4513f567279467332212f3eebcb68279885f1d525d7aaebbb452f522b02c0b5cd3ca66f385341e4b4eac67
   languageName: node
   linkType: hard
 
@@ -5659,6 +5850,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:8.4.31":
+  version: 8.4.31
+  resolution: "postcss@npm:8.4.31"
+  dependencies:
+    nanoid: "npm:^3.3.6"
+    picocolors: "npm:^1.0.0"
+    source-map-js: "npm:^1.0.2"
+  checksum: 10c0/748b82e6e5fc34034dcf2ae88ea3d11fd09f69b6c50ecdd3b4a875cfc7cdca435c958b211e2cb52355422ab6fccb7d8f2f2923161d7a1b281029e4a913d59acf
+  languageName: node
+  linkType: hard
+
 "postcss@npm:^8.4.38":
   version: 8.4.38
   resolution: "postcss@npm:8.4.38"
@@ -5772,7 +5974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.3.1":
+"react-dom@npm:^18.2.0, react-dom@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
   dependencies:
@@ -5791,7 +5993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18.3.1":
+"react@npm:^18.2.0, react@npm:^18.3.1":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
   dependencies:
@@ -6334,7 +6536,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.2.0":
+"source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.0":
   version: 1.2.0
   resolution: "source-map-js@npm:1.2.0"
   checksum: 10c0/7e5f896ac10a3a50fe2898e5009c58ff0dc102dcb056ed27a354623a0ece8954d4b2649e1a1b2b52ef2e161d26f8859c7710350930751640e71e374fe2d321a4
@@ -6443,6 +6645,13 @@ __metadata:
   dependencies:
     minipass: "npm:^3.1.1"
   checksum: 10c0/c5d153ce03b5980d683ecaa4d805f6a03d8dc545736213803e168a1907650c46c08a4e5ce6d670a0205482b35c35713d9d286d9133bdd79853a406e22ad81f04
+  languageName: node
+  linkType: hard
+
+"streamsearch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "streamsearch@npm:1.1.0"
+  checksum: 10c0/fbd9aecc2621364384d157f7e59426f4bfd385e8b424b5aaa79c83a6f5a1c8fd2e4e3289e95de1eb3511cb96bb333d6281a9919fafce760e4edb35b2cd2facab
   languageName: node
   linkType: hard
 
@@ -6565,6 +6774,22 @@ __metadata:
   bin:
     sl-log-transformer: bin/sl-log-transformer.js
   checksum: 10c0/3c3b8aa8f34d661910563ff996412e2f527fc814e699a376854b554d4a4294ab7e285b4e2c08a080a7b19c5600a9b93a98798d3ac600fe3de545ca6605c07829
+  languageName: node
+  linkType: hard
+
+"styled-jsx@npm:5.1.1":
+  version: 5.1.1
+  resolution: "styled-jsx@npm:5.1.1"
+  dependencies:
+    client-only: "npm:0.0.1"
+  peerDependencies:
+    react: ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    babel-plugin-macros:
+      optional: true
+  checksum: 10c0/42655cdadfa5388f8a48bb282d6b450df7d7b8cf066ac37038bd0499d3c9f084815ebd9ff9dfa12a218fd4441338851db79603498d7557207009c1cf4d609835
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Added `combineMiddlewares`, `defineMiddleware`, and related types for middleware management in Next.js applications.
- Created `middleware.ts`, `combine.ts`, `types.ts`, and `index.ts` files to support middleware configuration and usage.
- Implemented pathname-based middleware matching and request handling.
- Configured TypeScript, Vite, and npm scripts for build and publishing.
- Updated readme.md with installation instructions, usage examples, and contributor information.